### PR TITLE
Fix for django 3.0

### DIFF
--- a/WebHashcat/Auth/templates/Auth/auth.html
+++ b/WebHashcat/Auth/templates/Auth/auth.html
@@ -1,4 +1,4 @@
-{% load staticfiles %}
+{% load static %}
 
 <!DOCTYPE html>
 <html lang="en">

--- a/WebHashcat/Hashcat/templates/base.html
+++ b/WebHashcat/Hashcat/templates/base.html
@@ -1,4 +1,4 @@
-{% load staticfiles %}
+{% load static %}
 
 <!DOCTYPE html>
 <html lang="en">


### PR DESCRIPTION
`staticfiles` has been deprecated in Django 2.1 and was removed in Django 3.0 in favor of `static`
So I replaced the two occurences of `{% load staticfiles %}` with `{% load static %}` in the auth.html and base.html templates.

https://docs.djangoproject.com/en/2.2/releases/2.1/#features-deprecated-in-2-1
https://docs.djangoproject.com/en/dev/releases/3.0/#features-removed-in-3-0

